### PR TITLE
Cleanup solution, refactoring

### DIFF
--- a/samples/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet.csproj
+++ b/samples/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet.csproj
@@ -45,11 +45,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Hystrix.Dotnet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hystrix.Dotnet.1.0.0-beta4\lib\net45\Hystrix.Dotnet.dll</HintPath>
+      <HintPath>..\packages\Hystrix.Dotnet.1.0.3\lib\net45\Hystrix.Dotnet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Hystrix.Dotnet.AspNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Hystrix.Dotnet.AspNet.1.0.0-beta4\lib\net45\Hystrix.Dotnet.AspNet.dll</HintPath>
+      <HintPath>..\packages\Hystrix.Dotnet.AspNet.1.0.3\lib\net45\Hystrix.Dotnet.AspNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JitterMagic, Version=1.1.3.0, Culture=neutral, processorArchitecture=MSIL">

--- a/samples/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet/packages.config
+++ b/samples/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Hystrix.Dotnet" version="1.0.0-beta4" targetFramework="net45" />
-  <package id="Hystrix.Dotnet.AspNet" version="1.0.0-beta4" targetFramework="net45" />
+  <package id="Hystrix.Dotnet" version="1.0.3" targetFramework="net45" />
+  <package id="Hystrix.Dotnet.AspNet" version="1.0.3" targetFramework="net45" />
   <package id="JitterMagic" version="1.1.3" targetFramework="net45" />
   <package id="log4net" version="2.0.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net452" />

--- a/samples/Hystrix.Dotnet.Samples.AspNetCore/Hystrix.Dotnet.Samples.AspNetCore.csproj
+++ b/samples/Hystrix.Dotnet.Samples.AspNetCore/Hystrix.Dotnet.Samples.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Hystrix.Dotnet.AspNetCore" Version="1.0.2" />
+    <PackageReference Include="Hystrix.Dotnet.AspNetCore" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>ASP.NET extensions for Hystrix.Dotnet, the .NET version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFramework>net45</TargetFramework>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet.AspNet/HystrixCommandElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixCommandElement.cs
@@ -7,106 +7,106 @@ namespace Hystrix.Dotnet.AspNet
         [ConfigurationProperty("key", IsRequired = true)]
         public string Key
         {
-            get { return this["key"].ToString(); }
-            set { this["key"] = value; }
+            get => this["key"].ToString();
+            set => this["key"] = value;
         }
 
         [ConfigurationProperty("commandTimeoutInMilliseconds", IsRequired = false, DefaultValue = 1000)]
         public int CommandTimeoutInMilliseconds
         {
-            get { return (int)this["commandTimeoutInMilliseconds"]; }
-            set { this["commandTimeoutInMilliseconds"] = value; }
+            get => (int)this["commandTimeoutInMilliseconds"];
+            set => this["commandTimeoutInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("circuitBreakerForcedOpen", IsRequired = false, DefaultValue = false)]
         public bool CircuitBreakerForcedOpen
         {
-            get { return (bool)this["circuitBreakerForcedOpen"]; }
-            set { this["circuitBreakerForcedOpen"] = value; }
+            get => (bool)this["circuitBreakerForcedOpen"];
+            set => this["circuitBreakerForcedOpen"] = value;
         }
 
         [ConfigurationProperty("circuitBreakerForcedClosed", IsRequired = false, DefaultValue = false)]
         public bool CircuitBreakerForcedClosed
         {
-            get { return (bool)this["circuitBreakerForcedClosed"]; }
-            set { this["circuitBreakerForcedClosed"] = value; }
+            get => (bool)this["circuitBreakerForcedClosed"];
+            set => this["circuitBreakerForcedClosed"] = value;
         }
 
         [ConfigurationProperty("circuitBreakerErrorThresholdPercentage", IsRequired = false, DefaultValue = 50)]
         public int CircuitBreakerErrorThresholdPercentage
         {
-            get { return (int)this["circuitBreakerErrorThresholdPercentage"]; }
-            set { this["circuitBreakerErrorThresholdPercentage"] = value; }
+            get => (int)this["circuitBreakerErrorThresholdPercentage"];
+            set => this["circuitBreakerErrorThresholdPercentage"] = value;
         }
 
         [ConfigurationProperty("circuitBreakerSleepWindowInMilliseconds", IsRequired = false, DefaultValue = 5000)]
         public int CircuitBreakerSleepWindowInMilliseconds
         {
-            get { return (int)this["circuitBreakerSleepWindowInMilliseconds"]; }
-            set { this["circuitBreakerSleepWindowInMilliseconds"] = value; }
+            get => (int)this["circuitBreakerSleepWindowInMilliseconds"];
+            set => this["circuitBreakerSleepWindowInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("circuitBreakerRequestVolumeThreshold", IsRequired = false, DefaultValue = 20)]
         public int CircuitBreakerRequestVolumeThreshold
         {
-            get { return (int)this["circuitBreakerRequestVolumeThreshold"]; }
-            set { this["circuitBreakerRequestVolumeThreshold"] = value; }
+            get => (int)this["circuitBreakerRequestVolumeThreshold"];
+            set => this["circuitBreakerRequestVolumeThreshold"] = value;
         }
 
         [ConfigurationProperty("metricsHealthSnapshotIntervalInMilliseconds", IsRequired = false, DefaultValue = 500)]
         public int MetricsHealthSnapshotIntervalInMilliseconds
         {
-            get { return (int)this["metricsHealthSnapshotIntervalInMilliseconds"]; }
-            set { this["metricsHealthSnapshotIntervalInMilliseconds"] = value; }
+            get => (int)this["metricsHealthSnapshotIntervalInMilliseconds"];
+            set => this["metricsHealthSnapshotIntervalInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("metricsRollingStatisticalWindowInMilliseconds", IsRequired = false, DefaultValue = 10000)]
         public int MetricsRollingStatisticalWindowInMilliseconds
         {
-            get { return (int)this["metricsRollingStatisticalWindowInMilliseconds"]; }
-            set { this["metricsRollingStatisticalWindowInMilliseconds"] = value; }
+            get => (int)this["metricsRollingStatisticalWindowInMilliseconds"];
+            set => this["metricsRollingStatisticalWindowInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("metricsRollingStatisticalWindowBuckets", IsRequired = false, DefaultValue = 10)]
         public int MetricsRollingStatisticalWindowBuckets
         {
-            get { return (int)this["metricsRollingStatisticalWindowBuckets"]; }
-            set { this["metricsRollingStatisticalWindowBuckets"] = value; }
+            get => (int)this["metricsRollingStatisticalWindowBuckets"];
+            set => this["metricsRollingStatisticalWindowBuckets"] = value;
         }
 
         [ConfigurationProperty("metricsRollingPercentileEnabled", IsRequired = false, DefaultValue = true)]
         public bool MetricsRollingPercentileEnabled
         {
-            get { return (bool)this["metricsRollingPercentileEnabled"]; }
-            set { this["metricsRollingPercentileEnabled"] = value; }
+            get => (bool)this["metricsRollingPercentileEnabled"];
+            set => this["metricsRollingPercentileEnabled"] = value;
         }
 
         [ConfigurationProperty("metricsRollingPercentileWindowInMilliseconds", IsRequired = false, DefaultValue = 60000)]
         public int MetricsRollingPercentileWindowInMilliseconds
         {
-            get { return (int)this["metricsRollingPercentileWindowInMilliseconds"]; }
-            set { this["metricsRollingPercentileWindowInMilliseconds"] = value; }
+            get => (int)this["metricsRollingPercentileWindowInMilliseconds"];
+            set => this["metricsRollingPercentileWindowInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("metricsRollingPercentileWindowBuckets", IsRequired = false, DefaultValue = 6)]
         public int MetricsRollingPercentileWindowBuckets
         {
-            get { return (int)this["metricsRollingPercentileWindowBuckets"]; }
-            set { this["metricsRollingPercentileWindowBuckets"] = value; }
+            get => (int)this["metricsRollingPercentileWindowBuckets"];
+            set => this["metricsRollingPercentileWindowBuckets"] = value;
         }
 
         [ConfigurationProperty("metricsRollingPercentileBucketSize", IsRequired = false, DefaultValue = 100)]
         public int MetricsRollingPercentileBucketSize
         {
-            get { return (int)this["metricsRollingPercentileBucketSize"]; }
-            set { this["metricsRollingPercentileBucketSize"] = value; }
+            get => (int)this["metricsRollingPercentileBucketSize"];
+            set => this["metricsRollingPercentileBucketSize"] = value;
         }
 
         [ConfigurationProperty("hystrixCommandEnabled", IsRequired = false, DefaultValue = true)]
         public bool HystrixCommandEnabled
         {
-            get { return (bool)this["hystrixCommandEnabled"]; }
-            set { this["hystrixCommandEnabled"] = value; }
+            get => (bool)this["hystrixCommandEnabled"];
+            set => this["hystrixCommandEnabled"] = value;
         }
     }
 }

--- a/src/Hystrix.Dotnet.AspNet/HystrixCommandGroupCollection.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixCommandGroupCollection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Configuration;
+﻿using System.Configuration;
 
 namespace Hystrix.Dotnet.AspNet
 {

--- a/src/Hystrix.Dotnet.AspNet/HystrixCommandGroupElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixCommandGroupElement.cs
@@ -7,16 +7,16 @@ namespace Hystrix.Dotnet.AspNet
         [ConfigurationProperty("key", IsRequired = true)]
         public string Key
         {
-            get { return this["key"].ToString(); }
-            set { this["key"] = value; }
+            get => this["key"].ToString();
+            set => this["key"] = value;
         }
 
         [ConfigurationProperty("commands", IsDefaultCollection = true)]
         [ConfigurationCollection(typeof(HystrixCommandElement), AddItemName = "add", ClearItemsName = "clear", RemoveItemName = "remove")]
         public HystrixCommandCollection Commands
         {
-            get { return (HystrixCommandCollection)this["commands"]; }
-            set { this["commands"] = value; }
+            get => (HystrixCommandCollection)this["commands"];
+            set => this["commands"] = value;
         }
     }
 }

--- a/src/Hystrix.Dotnet.AspNet/HystrixConfigSection.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixConfigSection.cs
@@ -7,29 +7,29 @@ namespace Hystrix.Dotnet.AspNet
         [ConfigurationProperty("serviceImplementation", DefaultValue = "HystrixLocalConfigurationService", IsRequired = false)]
         public string ServiceImplementation
         {
-            get { return this["serviceImplementation"].ToString(); }
-            set { this["serviceImplementation"] = value; }
+            get => this["serviceImplementation"].ToString();
+            set => this["serviceImplementation"] = value;
         }
 
         [ConfigurationProperty("metricsStreamPollIntervalInMilliseconds", DefaultValue = "500", IsRequired = false)]
         public int MetricsStreamPollIntervalInMilliseconds
         {
-            get { return (int)this["metricsStreamPollIntervalInMilliseconds"]; }
-            set { this["metricsStreamPollIntervalInMilliseconds"] = value; }
+            get => (int)this["metricsStreamPollIntervalInMilliseconds"];
+            set => this["metricsStreamPollIntervalInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("jsonConfigurationSourceOptions")]
         public HystrixJsonConfigurationSourceOptionsElement JsonConfigurationSourceOptions
         {
-            get { return this["jsonConfigurationSourceOptions"] as HystrixJsonConfigurationSourceOptionsElement; }
-            set { this["jsonConfigurationSourceOptions"] = value; }
+            get => this["jsonConfigurationSourceOptions"] as HystrixJsonConfigurationSourceOptionsElement;
+            set => this["jsonConfigurationSourceOptions"] = value;
         }
 
         [ConfigurationProperty("localOptions")]
         public HystrixLocalOptionsElement LocalOptions
         {
-            get { return this["localOptions"] as HystrixLocalOptionsElement; }
-            set { this["localOptions"] = value; }
+            get => this["localOptions"] as HystrixLocalOptionsElement;
+            set => this["localOptions"] = value;
         }
     }
 }

--- a/src/Hystrix.Dotnet.AspNet/HystrixJsonConfigurationSourceOptionsElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixJsonConfigurationSourceOptionsElement.cs
@@ -7,22 +7,22 @@ namespace Hystrix.Dotnet.AspNet
         [ConfigurationProperty("pollingIntervalInMilliseconds", IsRequired = false, DefaultValue = 60000)]
         public int PollingIntervalInMilliseconds 
         {
-            get { return (int)this["pollingIntervalInMilliseconds"]; }
-            set { this["pollingIntervalInMilliseconds"] = value; }
+            get => (int)this["pollingIntervalInMilliseconds"];
+            set => this["pollingIntervalInMilliseconds"] = value;
         }
 
         [ConfigurationProperty("locationPattern", IsRequired = true)]
         public string LocationPattern
         {
-            get { return this["locationPattern"].ToString(); }
-            set { this["locationPattern"] = value; }
+            get => this["locationPattern"].ToString();
+            set => this["locationPattern"] = value;
         }
 
         [ConfigurationProperty("baseLocation", IsRequired = true)]
         public string BaseLocation
         {
-            get { return this["baseLocation"].ToString(); }
-            set { this["baseLocation"] = value; }
+            get => this["baseLocation"].ToString();
+            set => this["baseLocation"] = value;
         }
     }
 }

--- a/src/Hystrix.Dotnet.AspNet/HystrixLocalOptionsElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixLocalOptionsElement.cs
@@ -8,8 +8,8 @@ namespace Hystrix.Dotnet.AspNet
         [ConfigurationCollection(typeof(HystrixCommandGroupElement), AddItemName = "add", ClearItemsName = "clear", RemoveItemName = "remove")]
         public HystrixCommandGroupCollection CommandGroups
         {
-            get { return (HystrixCommandGroupCollection)this["commandGroups"]; }
-            set { this["commandGroups"] = value; }
+            get => (HystrixCommandGroupCollection)this["commandGroups"];
+            set => this["commandGroups"] = value;
         }
     }
 }

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>ASP.NET extensions for Hystrix.Dotnet, the .NET version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet/DateTimeProvider.cs
+++ b/src/Hystrix.Dotnet/DateTimeProvider.cs
@@ -2,11 +2,9 @@
 
 namespace Hystrix.Dotnet
 {
-    public class DateTimeProvider
+    public class DateTimeProvider : IDateTimeProvider
     {
-        public virtual long GetCurrentTimeInMilliseconds()
-        {
-            return DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
-        }
+        public long CurrentTimeInMilliseconds =>
+            DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond;
     }
 }

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A combination of circuit breaker and timeout. The .net version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet/HystrixCommand.cs
+++ b/src/Hystrix.Dotnet/HystrixCommand.cs
@@ -65,7 +65,7 @@ namespace Hystrix.Dotnet
         {
             return InnerExecute(
                 primaryFunction,
-                innerExceptions => { throw new HystrixCommandException(innerExceptions); },
+                innerExceptions => throw new HystrixCommandException(innerExceptions),
                 cancellationTokenSource);
         }
 
@@ -155,7 +155,7 @@ namespace Hystrix.Dotnet
         {
             return await InnerExecuteAsync(
                 primaryFunction,
-                innerExceptions => { throw new HystrixCommandException(innerExceptions); },
+                innerExceptions => throw new HystrixCommandException(innerExceptions),
                 cancellationTokenSource).ConfigureAwait(false);
         }
 

--- a/src/Hystrix.Dotnet/HystrixCommandFactory.cs
+++ b/src/Hystrix.Dotnet/HystrixCommandFactory.cs
@@ -15,12 +15,7 @@ namespace Hystrix.Dotnet
 
         public HystrixCommandFactory(HystrixOptions options)
         {
-            if (options == null)
-            {
-                throw new ArgumentException("The HystrixOptions must be specified in order to use Hystrix.Dotnet", nameof(options));
-            }
-
-            this.options = options;
+            this.options = options ?? throw new ArgumentException("The HystrixOptions must be specified in order to use Hystrix.Dotnet", nameof(options));
         }
 
         public IHystrixCommand GetHystrixCommand(HystrixCommandIdentifier commandIdentifier)
@@ -62,10 +57,12 @@ namespace Hystrix.Dotnet
                 ? (IHystrixConfigurationService)new HystrixJsonConfigConfigurationService(commandIdentifier, options.JsonConfigurationSourceOptions)
                 : new HystrixLocalConfigurationService(commandIdentifier, options.LocalOptions);
 
-            var commandMetrics = new HystrixCommandMetrics(commandIdentifier, configurationService);
+            var dateTimeProvider = new DateTimeProvider();
+
+            var commandMetrics = new HystrixCommandMetrics(dateTimeProvider, configurationService);
             var timeoutWrapper = new HystrixTimeoutWrapper(commandIdentifier, configurationService);
-            var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationService, commandMetrics);
-            var threadPoolMetrics = new HystrixThreadPoolMetrics(commandIdentifier, configurationService);
+            var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider, commandIdentifier, configurationService, commandMetrics);
+            var threadPoolMetrics = new HystrixThreadPoolMetrics(dateTimeProvider, configurationService);
 
             return new HystrixCommand(commandIdentifier, timeoutWrapper, circuitBreaker, commandMetrics, threadPoolMetrics, configurationService);
         }

--- a/src/Hystrix.Dotnet/HystrixJsonConfigConfigurationService.cs
+++ b/src/Hystrix.Dotnet/HystrixJsonConfigConfigurationService.cs
@@ -27,17 +27,12 @@ namespace Hystrix.Dotnet
 
         public HystrixJsonConfigConfigurationService(HystrixCommandIdentifier commandIdentifier, HystrixJsonConfigurationSourceOptions options)
         {
-            if (commandIdentifier == null)
-            {
-                throw new ArgumentNullException(nameof(commandIdentifier));
-            }
-
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            this.commandIdentifier = commandIdentifier;
+            this.commandIdentifier = commandIdentifier ?? throw new ArgumentNullException(nameof(commandIdentifier));
 
             pollingIntervalInMillisecond = options.PollingIntervalInMilliseconds;
 
@@ -111,7 +106,7 @@ namespace Hystrix.Dotnet
                 }
                 catch (Exception ex)
                 {
-                    log.Warn(string.Format("Failed loading {0}", configurationFileUrl), ex);
+                    log.Warn($"Failed loading {configurationFileUrl}", ex);
                 }
             }).ConfigureAwait(false);
         }
@@ -165,7 +160,7 @@ namespace Hystrix.Dotnet
             }
             else
             {
-                var message = string.Format("Schema {0} for base url {1} is not supported", configurationFileUrl.Scheme, configurationFileUrl);
+                var message = $"Schema {configurationFileUrl.Scheme} for base url {configurationFileUrl} is not supported";
                 log.Error(message);
                 throw new NotSupportedException(message);
             }

--- a/src/Hystrix.Dotnet/HystrixThreadPoolMetrics.cs
+++ b/src/Hystrix.Dotnet/HystrixThreadPoolMetrics.cs
@@ -8,19 +8,11 @@ namespace Hystrix.Dotnet
 
         public IHystrixConfigurationService ConfigurationService { get; }
 
-        public HystrixThreadPoolMetrics(HystrixCommandIdentifier commandIdentifier, IHystrixConfigurationService configurationService)
+        public HystrixThreadPoolMetrics(IDateTimeProvider dateTimeProvider, IHystrixConfigurationService configurationService)
         {
-            if (commandIdentifier == null)
-            {
-                throw new ArgumentNullException(nameof(commandIdentifier));
-            }
-            if (configurationService == null)
-            {
-                throw new ArgumentNullException(nameof(configurationService));
-            }
-            ConfigurationService = configurationService;
+            ConfigurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
 
-            counter = new HystrixRollingNumber(configurationService.GetMetricsRollingStatisticalWindowInMilliseconds(), configurationService.GetMetricsRollingStatisticalWindowBuckets());
+            counter = new HystrixRollingNumber(dateTimeProvider, configurationService.GetMetricsRollingStatisticalWindowInMilliseconds(), configurationService.GetMetricsRollingStatisticalWindowBuckets());
         }
 
         public int GetCurrentActiveCount()

--- a/src/Hystrix.Dotnet/HystrixTimeoutWrapper.cs
+++ b/src/Hystrix.Dotnet/HystrixTimeoutWrapper.cs
@@ -45,7 +45,7 @@ namespace Hystrix.Dotnet
             catch (AggregateException ae)
             {                
                 // unwrap exception, the Wait or Result wraps it in an AggregateException
-                throw ae.InnerException;
+                throw ae.InnerException ?? ae;
             }
 
             // primaryFunction continues to occupy a thread until it finishes, although nothing will be done with the result; unless we have a cancellationToken and can cancel the task

--- a/src/Hystrix.Dotnet/IDateTimeProvider.cs
+++ b/src/Hystrix.Dotnet/IDateTimeProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Hystrix.Dotnet
+{
+    public interface IDateTimeProvider
+    {
+        long CurrentTimeInMilliseconds { get; }
+    }
+}

--- a/src/Hystrix.Dotnet/LibLog.cs
+++ b/src/Hystrix.Dotnet/LibLog.cs
@@ -419,7 +419,7 @@ namespace Hystrix.Dotnet.Logging
         {
             if (logger == null)
             {
-                throw new ArgumentNullException("logger");
+                throw new ArgumentNullException(nameof(logger));
             }
         }
 

--- a/src/Hystrix.Dotnet/Metrics/HystrixMetricsStreamEndpoint.cs
+++ b/src/Hystrix.Dotnet/Metrics/HystrixMetricsStreamEndpoint.cs
@@ -29,17 +29,12 @@ namespace Hystrix.Dotnet.Metrics
 
         public HystrixMetricsStreamEndpoint(IHystrixCommandFactory commandFactory, int pollingInterval)
         {
-            if (commandFactory == null)
-            {
-                throw new ArgumentNullException(nameof(commandFactory));
-            }
-
             if (pollingInterval < 100)
             {
                 throw new ArgumentOutOfRangeException(nameof(pollingInterval), "Parameter pollingInterval needs to be greater than or equal to 100");
             }
 
-            this.commandFactory = commandFactory;
+            this.commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
             this.pollingInterval = pollingInterval;
         }
 
@@ -127,7 +122,7 @@ namespace Hystrix.Dotnet.Metrics
                     type = "HystrixCommand",
                     name = commandIdentifier.CommandKey,
                     group = commandIdentifier.GroupKey,
-                    currentTime = dateTimeProvider.GetCurrentTimeInMilliseconds(),
+                    currentTime = dateTimeProvider.CurrentTimeInMilliseconds,
                     isCircuitBreakerOpen = circuitBreaker != null && circuitBreaker.CircuitIsOpen,
 
                     errorPercentage = healthCounts.GetErrorPercentage(),

--- a/test/Hystrix.Dotnet.AspNet.UnitTests/Hystrix.Dotnet.AspNet.UnitTests.csproj
+++ b/test/Hystrix.Dotnet.AspNet.UnitTests/Hystrix.Dotnet.AspNet.UnitTests.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="moq" Version="4.7.10" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/test/Hystrix.Dotnet.UnitTests/HystrixCircuitBreakerTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixCircuitBreakerTests.cs
@@ -9,33 +9,47 @@ namespace Hystrix.Dotnet.UnitTests
         public class Constructor
         {
             [Fact]
+            public void Throws_ArgumentNullException_When_DateTimeProvider_Is_Null()
+            {
+                var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
+                var commandIdentifier = new HystrixCommandIdentifier("group", "key");
+                var configurationServiceMock = new Mock<IHystrixConfigurationService>();
+
+                // Act
+                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(null, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object));
+            }
+
+            [Fact]
             public void Throws_ArgumentNullException_When_CommandIdentifier_Is_Null()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
                 // Act
-                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(null, configurationServiceMock.Object, commandMetricsMock.Object));
+                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(dateTimeProvider.Object, null, configurationServiceMock.Object, commandMetricsMock.Object));
             }
 
             [Fact]
             public void Throws_ArgumentNullException_When_ConfigurationService_Is_Null()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
 
                 // Act
-                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(commandIdentifier, null, commandMetricsMock.Object));
+                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, null, commandMetricsMock.Object));
             }
 
             [Fact]
             public void Throws_ArgumentNullException_When_MetricsCollector_Is_Null()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
                 // Act
-                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, null));
+                Assert.Throws<ArgumentNullException>(() => new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, null));
             }
         }
 
@@ -44,10 +58,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_False_When_GetCircuitBreakerForcedOpen_Is_True()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerForcedOpen()).Returns(true);
 
@@ -60,10 +75,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_True_When_GetCircuitBreakerForcedClosed_Is_True()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerForcedClosed()).Returns(true);
 
@@ -76,10 +92,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_True_When_TotalRequests_Is_Less_Than_GetCircuitBreakerRequestVolumeThreshold()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 commandMetricsMock.Setup(collector => collector.GetHealthCounts()).Returns(new HystrixHealthCounts(99, 16, 16));
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerRequestVolumeThreshold()).Returns(100);
@@ -93,10 +110,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_True_When_ErrorPercentage_Is_Less_Than_GetCircuitBreakerErrorThresholdPercentage()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 commandMetricsMock.Setup(collector => collector.GetHealthCounts()).Returns(new HystrixHealthCounts(100, 16, 16));
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerErrorThresholdPercentage()).Returns(17);
@@ -110,10 +128,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Opens_Circuit_When_ErrorPercentage_Is_Less_Than_GetCircuitBreakerErrorThresholdPercentage()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 commandMetricsMock.Setup(collector => collector.GetHealthCounts()).Returns(new HystrixHealthCounts(100, 16, 16));
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerErrorThresholdPercentage()).Returns(16);
@@ -129,7 +148,7 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_False_When_ErrorPercentage_Is_Less_Than_GetCircuitBreakerErrorThresholdPercentage()
             {
-                var dateTimeProviderMock = new Mock<DateTimeProvider>();
+                var dateTimeProviderMock = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
@@ -137,7 +156,7 @@ namespace Hystrix.Dotnet.UnitTests
 
                 commandMetricsMock.Setup(collector => collector.GetHealthCounts()).Returns(new HystrixHealthCounts(100, 16, 16));
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerErrorThresholdPercentage()).Returns(16);
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(0);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(0);
 
                 // Act
                 bool allowRequest = circuitBreaker.AllowRequest();
@@ -148,13 +167,13 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_False_When_Circuit_Is_Open()
             {
-                var dateTimeProviderMock = new Mock<DateTimeProvider>();
+                var dateTimeProviderMock = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
                 var circuitBreaker = new HystrixCircuitBreaker(dateTimeProviderMock.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(0);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(0);
                 circuitBreaker.OpenCircuit();
 
                 // Act
@@ -166,17 +185,17 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_True_When_Circuit_Is_Open_But_Request_Is_First_After_GetCircuitBreakerSleepWindowInMilliseconds()
             {
-                var dateTimeProviderMock = new Mock<DateTimeProvider>();
+                var dateTimeProviderMock = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
                 var circuitBreaker = new HystrixCircuitBreaker(dateTimeProviderMock.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(0);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(0);
                 circuitBreaker.OpenCircuit();
 
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerSleepWindowInMilliseconds()).Returns(5000);
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(6000);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(6000);
 
                 // Act
                 bool allowRequest = circuitBreaker.AllowRequest();
@@ -187,17 +206,17 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_False_When_Circuit_Is_Open_But_Request_Is_First_After_GetCircuitBreakerSleepWindowInMilliseconds()
             {
-                var dateTimeProviderMock = new Mock<DateTimeProvider>();
+                var dateTimeProviderMock = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
                 var circuitBreaker = new HystrixCircuitBreaker(dateTimeProviderMock.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(0);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(0);
                 circuitBreaker.OpenCircuit();
 
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerSleepWindowInMilliseconds()).Returns(5000);
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(6000);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(6000);
 
                 // first request
                 circuitBreaker.AllowRequest();
@@ -211,10 +230,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_True_When_Circuit_Has_Been_Closed_After_Being_Open()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 commandMetricsMock.Setup(collector => collector.GetHealthCounts()).Returns(new HystrixHealthCounts(100, 16, 16));
                 configurationServiceMock.Setup(service => service.GetCircuitBreakerErrorThresholdPercentage()).Returns(17);
@@ -234,10 +254,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Opens_The_Circuit_When_Closed()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 Assert.False(circuitBreaker.CircuitIsOpen);
 
@@ -250,10 +271,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Keeps_The_Circuit_Open_When_Open()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 circuitBreaker.OpenCircuit();
                 Assert.True(circuitBreaker.CircuitIsOpen);
@@ -271,10 +293,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Closes_The_Circuit_When_Open()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 circuitBreaker.OpenCircuit();
                 Assert.True(circuitBreaker.CircuitIsOpen);
@@ -288,10 +311,11 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Keeps_The_Circuit_Closed_When_Closed()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var commandIdentifier = new HystrixCommandIdentifier("group", "key");
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 var commandMetricsMock = new Mock<IHystrixCommandMetrics>();
-                var circuitBreaker = new HystrixCircuitBreaker(commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
+                var circuitBreaker = new HystrixCircuitBreaker(dateTimeProvider.Object, commandIdentifier, configurationServiceMock.Object, commandMetricsMock.Object);
 
                 circuitBreaker.OpenCircuit();
                 Assert.True(circuitBreaker.CircuitIsOpen);

--- a/test/Hystrix.Dotnet.UnitTests/HystrixCommandFactoryTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixCommandFactoryTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Hystrix.Dotnet.UnitTests
@@ -75,7 +74,7 @@ namespace Hystrix.Dotnet.UnitTests
                 for (int i = 0; i < 100000; i++)
                 {
                     var commandIdentifier = new HystrixCommandIdentifier("group", "key"+ (i%10));
-                    var hystrixCommand = factory.GetHystrixCommand(commandIdentifier);
+                    factory.GetHystrixCommand(commandIdentifier);
                 }
 
                 stopwatch.Stop();
@@ -83,6 +82,7 @@ namespace Hystrix.Dotnet.UnitTests
             }
         }
 
+        // ReSharper disable once InconsistentNaming
         public class GetHystrixCommand_With_GroupKey_And_CommandKey
         {
             private readonly HystrixOptions defaultOptions = HystrixOptions.CreateDefault();
@@ -149,7 +149,7 @@ namespace Hystrix.Dotnet.UnitTests
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 for (int i = 0; i < 100000; i++)
                 {
-                    var hystrixCommand = factory.GetHystrixCommand("group", "key" + (i % 10));
+                    factory.GetHystrixCommand("group", "key" + (i % 10));
                 }
 
                 stopwatch.Stop();

--- a/test/Hystrix.Dotnet.UnitTests/HystrixCommandMetricsTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixCommandMetricsTests.cs
@@ -9,7 +9,7 @@ namespace Hystrix.Dotnet.UnitTests
         public class Constructor
         {
             [Fact]
-            public void Throws_ArgumentNullException_When_CommandIdentifier_Is_Null()
+            public void Throws_ArgumentNullException_When_DateTimeProvider_Is_Null()
             {
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
@@ -20,10 +20,10 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Throws_ArgumentNullException_When_ConfigurationService_Is_Null()
             {
-                var commandIdentifier = new HystrixCommandIdentifier("group", "key");
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
 
                 // Act
-                Assert.Throws<ArgumentNullException>(() => new HystrixCommandMetrics(commandIdentifier, null));
+                Assert.Throws<ArgumentNullException>(() => new HystrixCommandMetrics(dateTimeProvider.Object, null));
             }
         }
 
@@ -32,14 +32,14 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_HealthCounts_With_All_Zero_Values_When_No_Requests_Have_Been_Processed()
             {
-                var commandIdentifier = new HystrixCommandIdentifier("group", "key");
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 configurationServiceMock.Setup(service => service.GetMetricsRollingStatisticalWindowInMilliseconds()).Returns(10000);
                 configurationServiceMock.Setup(service => service.GetMetricsRollingStatisticalWindowBuckets()).Returns(10);
                 configurationServiceMock.Setup(service => service.GetMetricsRollingPercentileWindowInMilliseconds()).Returns(10000);
                 configurationServiceMock.Setup(service => service.GetMetricsRollingPercentileWindowBuckets()).Returns(10);
                 configurationServiceMock.Setup(service => service.GetMetricsRollingPercentileBucketSize()).Returns(1000);
-                var metricsCollector = new HystrixCommandMetrics(commandIdentifier, configurationServiceMock.Object);
+                var metricsCollector = new HystrixCommandMetrics(dateTimeProvider.Object, configurationServiceMock.Object);
 
                 // Act
                 var healthCounts = metricsCollector.GetHealthCounts();

--- a/test/Hystrix.Dotnet.UnitTests/HystrixCommandTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixCommandTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Xunit;
+// ReSharper disable MethodSupportsCancellation
 
 namespace Hystrix.Dotnet.UnitTests
 {
@@ -1769,7 +1770,7 @@ namespace Hystrix.Dotnet.UnitTests
                 configurationServiceMock.Setup(x => x.GetHystrixCommandEnabled()).Returns(true);
                 circuitBreakerMock.Setup(x => x.AllowRequest()).Returns(false);
                 // http://stackoverflow.com/questions/537308/how-to-verify-that-method-was-not-called-in-moq
-                commandMetricsMock.Setup(x => x.MarkFallbackSuccess()).Throws(new Exception("Shouldn't be called.")); ;
+                commandMetricsMock.Setup(x => x.MarkFallbackSuccess()).Throws(new Exception("Shouldn't be called."));
 
                 // Act
                 await Assert.ThrowsAsync<Exception>(() => hystrixCommand.ExecuteAsync(primaryFunction, fallbackFunction));

--- a/test/Hystrix.Dotnet.UnitTests/HystrixJsonConfigConfigurationServiceTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixJsonConfigConfigurationServiceTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Stubbery;
 using Xunit;
 

--- a/test/Hystrix.Dotnet.UnitTests/HystrixRollingNumberTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixRollingNumberTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Moq;
 using Xunit;
 
 namespace Hystrix.Dotnet.UnitTests
@@ -8,43 +9,58 @@ namespace Hystrix.Dotnet.UnitTests
         public class Constructor
         {
             [Fact]
-            public void Throws_ArgumentOutOfRangeException_When_TimeInMilliseconds_Is_Zero_Or_Less()
+            public void Throws_ArgumentOutOfRangeException_When_DateTimeProvider_Is_Null()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 0;
                 var numberOfBuckets = 10;
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(timeInMilliseconds, numberOfBuckets));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets));
+            }
+
+            [Fact]
+            public void Throws_ArgumentOutOfRangeException_When_TimeInMilliseconds_Is_Zero_Or_Less()
+            {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var timeInMilliseconds = 0;
+                var numberOfBuckets = 10;
+
+                // Act
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets));
             }
 
             [Fact]
             public void Throws_ArgumentOutOfRangeException_When_NumberOfBuckets_Is_Zero_Or_Less()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 0;
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(timeInMilliseconds, numberOfBuckets));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets));
             }
 
             [Fact]
             public void Throws_ArgumentOutOfRangeException_When_TimeInMilliseconds_Is_Not_A_Multitude_Of_NumberOfBuckets()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 7;
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(timeInMilliseconds, numberOfBuckets));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingNumber(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets));
             }
 
             [Fact]
             public void Sets_TimeInMilliseconds_And_NumberOfBuckets()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 10;
 
                 // Act
-                var rollingNumber = new HystrixRollingNumber(timeInMilliseconds, numberOfBuckets);
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets);
 
                 Assert.Equal(10000, rollingNumber.TimeInMilliseconds);
                 Assert.Equal(10, rollingNumber.NumberOfBuckets);
@@ -53,11 +69,12 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Calculates_BucketSizeInMillseconds_From_TimeInMilliseconds_Divided_By_NumberOfBuckets()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 10;
 
                 // Act
-                var rollingNumber = new HystrixRollingNumber(timeInMilliseconds, numberOfBuckets);
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets);
 
                 Assert.Equal(1000, rollingNumber.BucketSizeInMillseconds);
             }
@@ -69,7 +86,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_Zero_If_No_Values_Have_Been_Added_Yet_For_Specific_Counter()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 long valueOfLatestBucket = rollingNumber.GetValueOfLatestBucket(HystrixRollingNumberEvent.Success);
@@ -83,7 +101,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Increments_The_Counter()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 rollingNumber.Increment(HystrixRollingNumberEvent.Success);
@@ -98,8 +117,9 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Adds_The_Value_To_The_Counter()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 long value = 15;
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 rollingNumber.Add(HystrixRollingNumberEvent.Success, value);
@@ -114,8 +134,9 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Sets_The_Max_Of_Current_Value_And_Passed_Value()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 long value = 15;
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 rollingNumber.UpdateRollingMax(HystrixRollingNumberEvent.CommandMaxActive, value);
@@ -130,7 +151,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Clears_All_Buckets()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
                 rollingNumber.Increment(HystrixRollingNumberEvent.Success);
 
                 long rollingSumBeforeReset = rollingNumber.GetRollingSum(HystrixRollingNumberEvent.Success);
@@ -149,7 +171,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void NotImplemented()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 long cumulativeSum = rollingNumber.GetCumulativeSum(HystrixRollingNumberEvent.Success);
@@ -163,7 +186,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void NotImplemented()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 long value =  rollingNumber.GetRollingSum(HystrixRollingNumberEvent.Success);
@@ -177,7 +201,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_Values_For_All_Buckets()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 long[] values = rollingNumber.GetValues(HystrixRollingNumberEvent.Success);
@@ -191,7 +216,8 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_Zero_If_No_Values_Have_Been_Recorded()
             {
-                var rollingNumber = new HystrixRollingNumber(10000, 10);
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
+                var rollingNumber = new HystrixRollingNumber(dateTimeProvider.Object, 10000, 10);
 
                 // Act
                 long rollingMaxValue = rollingNumber.GetRollingMaxValue(HystrixRollingNumberEvent.Success);

--- a/test/Hystrix.Dotnet.UnitTests/HystrixRollingPercentileTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixRollingPercentileTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using Hystrix.Dotnet.ConcurrencyUtilities;
 using Moq;
 using Xunit;
@@ -11,62 +10,79 @@ namespace Hystrix.Dotnet.UnitTests
         public class Constructor
         {
             [Fact]
+            public void Throws_ArgumentNullException_When_DateTimeProvider_Is_Null()
+            {
+                var timeInMilliseconds = 1000;
+                var numberOfBuckets = 10;
+                var bucketDataLength = 100;
+                var configurationServiceMock = new Mock<IHystrixConfigurationService>();
+
+                // Act
+                Assert.Throws<ArgumentNullException>(() => new HystrixRollingPercentile(null, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
+            }
+
+            [Fact]
             public void Throws_ArgumentOutOfRangeException_When_TimeInMilliseconds_Is_Zero_Or_Less()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 0;
                 var numberOfBuckets = 10;
                 var bucketDataLength = 100;
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
             }
 
             [Fact]
             public void Throws_ArgumentOutOfRangeException_When_NumberOfBuckets_Is_Zero_Or_Less()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 0;
                 var bucketDataLength = 100;
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
             }
 
             [Fact]
             public void Throws_ArgumentOutOfRangeException_When_BucketDataLength_Is_Less_Than_One_Hundred()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 10;
                 var bucketDataLength = 99;
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
             }
 
             [Fact]
             public void Throws_ArgumentNullException_When_ConfigurationService_Is_Null()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 0;
                 var bucketDataLength = 100;
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, null));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, null));
             }
 
             [Fact]
             public void Throws_ArgumentOutOfRangeException_When_TimeInMilliseconds_Is_Not_An_Exact_Multiple_Of_NumberOfBuckets()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 7;
                 var bucketDataLength = 100;
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
 
                 // Act
-                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
+                Assert.Throws<ArgumentOutOfRangeException>(() => new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object));
             }
         }
 
@@ -75,12 +91,14 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Adds_Value_To_Current_Bucket_When_GetMetricsRollingPercentileEnabled_Is_True()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 10;
                 var bucketDataLength = 100;
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 configurationServiceMock.Setup(x => x.GetMetricsRollingPercentileEnabled()).Returns(true);
-                var rollingPercentile = new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object);
+
+                var rollingPercentile = new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object);
 
                 // Act
                 rollingPercentile.AddValue(243);
@@ -92,16 +110,20 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void Returns_The_Mean_Of_All_Values_In_The_Snapshot_When_GetMetricsRollingPercentileEnabled_Is_True()
             {
+                var dateTimeProvider = new Mock<IDateTimeProvider>();
                 var timeInMilliseconds = 10000;
                 var numberOfBuckets = 10;
                 var bucketDataLength = 100;
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 configurationServiceMock.Setup(x => x.GetMetricsRollingPercentileEnabled()).Returns(true);
-                var rollingPercentile = new HystrixRollingPercentile(timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object);
+
+                dateTimeProvider.SetupGet(d => d.CurrentTimeInMilliseconds).Returns(0);
+
+                var rollingPercentile = new HystrixRollingPercentile(dateTimeProvider.Object, timeInMilliseconds, numberOfBuckets, bucketDataLength, configurationServiceMock.Object);
                 rollingPercentile.AddValue(243);
                 rollingPercentile.AddValue(157);
 
-                Thread.Sleep(1500);
+                dateTimeProvider.SetupGet(d => d.CurrentTimeInMilliseconds).Returns(1500);
 
                 // Act
                 var mean = rollingPercentile.GetMean();
@@ -124,12 +146,10 @@ namespace Hystrix.Dotnet.UnitTests
             [Fact]
             public void TestRolling()
             {
-                //MockedTime time = new MockedTime();
-                var dateTimeProviderMock = new Mock<DateTimeProvider>();
-                var currentTime = new DateTimeProvider().GetCurrentTimeInMilliseconds();
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(currentTime);
+                var dateTimeProviderMock = new Mock<IDateTimeProvider>();
+                var currentTime = new DateTime(2017, 6, 26, 14, 0, 0).Ticks / TimeSpan.TicksPerMillisecond;
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(currentTime);
 
-                //HystrixRollingPercentile p = new HystrixRollingPercentile(time, 60000, 12, 1000, true);
                 var configurationServiceMock = new Mock<IHystrixConfigurationService>();
                 configurationServiceMock.Setup(x => x.GetMetricsRollingPercentileEnabled()).Returns(true);
                 HystrixRollingPercentile p = new HystrixRollingPercentile(dateTimeProviderMock.Object, 60000, 12, 1000, configurationServiceMock.Object);
@@ -144,7 +164,7 @@ namespace Hystrix.Dotnet.UnitTests
                 Assert.Equal(0, p.GetPercentile(50));
 
                 currentTime += 6000;
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(currentTime);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(currentTime);
 
                 // still only 1 bucket until we touch it again
                 Assert.Equal(1, p.Buckets.Length);
@@ -173,7 +193,7 @@ namespace Hystrix.Dotnet.UnitTests
 
                 // increment to another bucket so we include all of the above in the PercentileSnapshot
                 currentTime += 6000;
-                dateTimeProviderMock.Setup(time => time.GetCurrentTimeInMilliseconds()).Returns(currentTime);
+                dateTimeProviderMock.Setup(time => time.CurrentTimeInMilliseconds).Returns(currentTime);
 
                 // the rolling version should have the same data as creating a snapshot like this
                 PercentileSnapshot ps = new PercentileSnapshot(1000, 1000, 1000, 2000, 1000, 500, 200, 200, 1600, 200, 1600, 1600);
@@ -182,13 +202,6 @@ namespace Hystrix.Dotnet.UnitTests
                 Assert.Equal(ps.GetPercentile(0.50), p.GetPercentile(0.50));
                 Assert.Equal(ps.GetPercentile(0.90), p.GetPercentile(0.90));
                 Assert.Equal(ps.GetPercentile(0.995), p.GetPercentile(0.995));
-
-                //System.out.println("100th: " + ps.GetPercentile(100) + "  " + p.GetPercentile(100));
-                //System.out.println("99.5th: " + ps.GetPercentile(99.5) + "  " + p.GetPercentile(99.5));
-                //System.out.println("99th: " + ps.GetPercentile(99) + "  " + p.GetPercentile(99));
-                //System.out.println("90th: " + ps.GetPercentile(90) + "  " + p.GetPercentile(90));
-                //System.out.println("50th: " + ps.GetPercentile(50) + "  " + p.GetPercentile(50));
-                //System.out.println("10th: " + ps.GetPercentile(10) + "  " + p.GetPercentile(10));
 
                 // mean = 1000+1000+1000+2000+1000+500+200+200+1600+200+1600+1600/12
                 Assert.Equal(991, ps.GetMean());

--- a/test/Hystrix.Dotnet.UnitTests/LongMaxUpdaterTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/LongMaxUpdaterTests.cs
@@ -5,7 +5,7 @@ namespace Hystrix.Dotnet.UnitTests
 {
     public class LongMaxUpdaterTests
     {
-        private LongMaxUpdater num = new LongMaxUpdater();
+        private readonly LongMaxUpdater num = new LongMaxUpdater();
 
         [Fact]
         public void LongMaxUpdater_DefaultsToLongMinValue()


### PR DESCRIPTION
Cleaned up all the code issues reported by ReSharper, and changed the way we're injecting the `IDateTimeProvider` so that we're not instantiating the actual implementation type inside classes which depend on it.