### PR TITLE
Fix concurrency handling in CircularArray.GetTail

### DIFF
--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>ASP.NET extensions for Hystrix.Dotnet, the .NET version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFramework>net45</TargetFramework>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>ASP.NET extensions for Hystrix.Dotnet, the .NET version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet/CircularArray.cs
+++ b/src/Hystrix.Dotnet/CircularArray.cs
@@ -30,6 +30,12 @@ namespace Hystrix.Dotnet
 
             var localArray = internalQueue.ToArray();
 
+            // NOTE: We have to do the check again, because another thread might have modified the queue in the meantime.
+            if (localArray.Length == 0)
+            {
+                return default(T);
+            }
+
             return localArray[localArray.Length - 1];
         }
 

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A combination of circuit breaker and timeout. The .net version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/test/Hystrix.Dotnet.AspNet.UnitTests/Hystrix.Dotnet.AspNet.UnitTests.csproj
+++ b/test/Hystrix.Dotnet.AspNet.UnitTests/Hystrix.Dotnet.AspNet.UnitTests.csproj
@@ -18,10 +18,10 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="moq" Version="4.7.10" />
+    <PackageReference Include="moq" Version="4.7.99" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Hystrix.Dotnet.AspNetCore.UnitTests/Hystrix.Dotnet.AspNetCore.UnitTests.csproj
+++ b/test/Hystrix.Dotnet.AspNetCore.UnitTests/Hystrix.Dotnet.AspNetCore.UnitTests.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="moq" Version="4.7.10" />
+    <PackageReference Include="moq" Version="4.7.99" />
   </ItemGroup>
 
 </Project>

--- a/test/Hystrix.Dotnet.UnitTests/Hystrix.Dotnet.UnitTests.csproj
+++ b/test/Hystrix.Dotnet.UnitTests/Hystrix.Dotnet.UnitTests.csproj
@@ -21,11 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="moq" Version="4.7.10" />
-    <PackageReference Include="Stubbery" Version="1.2.3" />
+    <PackageReference Include="moq" Version="4.7.99" />
+    <PackageReference Include="Stubbery" Version="1.2.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This was causing actual `IndexOutOfRangeException`s being thrown.