### PR TITLE
Add the capability to configure the Default fallback configuration when using local options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,4 +60,4 @@ artifacts:
 #     deployment configuration    #
 #---------------------------------#
 
-deploy: off  
+deploy: off

--- a/docs/documentation/configuration.md
+++ b/docs/documentation/configuration.md
@@ -43,6 +43,7 @@ There are two main modes of configuring our individual commands, based on the va
             </commands>
           </add>
         </commandGroups>
+        <defaultConfiguration commandTimeoutInMilliseconds="1500" />
       </localOptions>
     </hystrix>
   </hystrix.dotnet>
@@ -50,6 +51,8 @@ There are two main modes of configuring our individual commands, based on the va
 
 This way we can add multiple groups and commands, and fine-tune each independently.
 The above values are also the defaults if we omit any of the attributes. (Or if we don't add any configuration to the web.config.)
+
+In the `defaultConfiguration` element we can adjust the "default" configuration, which is used for commands which don't have specific configuration specified for them.
 
 ### ASP.NET Core
 
@@ -81,11 +84,16 @@ First add an **appsettings.json** to our project, with the following content.
                         "MetricsRollingPercentileBucketSize": 100
                     }
                 }
+            },
+            "DefaultOptions": {
+                "CommandTimeoutInMilliseconds": 1500
             }
         }
     }
 }
 ```
+
+In the `DefaultOptions` field we can adjust the "default" configuration, which is used for commands which don't have specific configuration specified for them.
 
 Then set up the options object in our DI configuration, in the `ConfigureServices` method of the `Startup` class.
 

--- a/samples/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet/Web.config
+++ b/samples/Hystrix.Dotnet.Samples.AspNet/Hystrix.Dotnet.Samples.AspNet/Web.config
@@ -13,6 +13,7 @@
   <hystrix.dotnet>
     <hystrix serviceImplementation="HystrixLocalConfigurationService" metricsStreamPollIntervalInMilliseconds="2000">
       <localOptions>
+        <defaultConfiguration commandTimeoutInMilliseconds="1500" />
         <commandGroups>
           <add key="TestGroup">
             <commands>

--- a/samples/Hystrix.Dotnet.Samples.AspNet/README.md
+++ b/samples/Hystrix.Dotnet.Samples.AspNet/README.md
@@ -27,6 +27,7 @@ Install-Package Hystrix.Dotnet.AspNet
             </commands>
           </add>
         </commandGroups>
+        <defaultConfiguration commandTimeoutInMilliseconds="1500" />
       </localOptions>
     </hystrix>
   </hystrix.dotnet>

--- a/samples/Hystrix.Dotnet.Samples.AspNetCore/Controllers/HelloController.cs
+++ b/samples/Hystrix.Dotnet.Samples.AspNetCore/Controllers/HelloController.cs
@@ -1,4 +1,3 @@
-using Hystrix.Dotnet;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;

--- a/samples/Hystrix.Dotnet.Samples.AspNetCore/README.md
+++ b/samples/Hystrix.Dotnet.Samples.AspNetCore/README.md
@@ -26,6 +26,9 @@ Add a dependency to the package `Hystrix.Dotnet.AspNetCore` in our project.json.
                         "CircuitBreakerErrorThresholdPercentage": 60
                     }
                 }
+            },
+            "DefaultOptions": {
+                "CommandTimeoutInMilliseconds": 1500
             }
         }
     }

--- a/samples/Hystrix.Dotnet.Samples.AspNetCore/appsettings.json
+++ b/samples/Hystrix.Dotnet.Samples.AspNetCore/appsettings.json
@@ -3,6 +3,10 @@
         "ConfigurationServiceImplementation": "HystrixLocalConfigurationService",
         "MetricsStreamPollIntervalInMilliseconds": 2000,
         "LocalOptions": {
+            "DefaultOptions": {
+                "CommandTimeoutInMilliseconds": 1500,
+                "CircuitBreakerErrorThresholdPercentage": 80
+            },
             "CommandGroups": {
                 "TestGroup": {
                     "TestCommand": {

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>ASP.NET extensions for Hystrix.Dotnet, the .NET version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFramework>net45</TargetFramework>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet.AspNet/HystrixConfigSectionTranslator.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixConfigSectionTranslator.cs
@@ -37,6 +37,7 @@ namespace Hystrix.Dotnet.AspNet
         {
             return new HystrixLocalOptions
             {
+                DefaultOptions = TranslateToCommandOptions(element.DefaultConfiguration),
                 CommandGroups = element.CommandGroups
                     .Cast<HystrixCommandGroupElement>()
                     .ToDictionary(
@@ -46,6 +47,27 @@ namespace Hystrix.Dotnet.AspNet
                             .ToDictionary(
                                 command => command.Key,
                                 TranslateToCommandOptions))
+            };
+        }
+
+        private HystrixCommandOptions TranslateToCommandOptions(HystrixDefaultConfigurationElement defaultConfig)
+        {
+            return new HystrixCommandOptions
+            {
+                CommandTimeoutInMilliseconds = defaultConfig.CommandTimeoutInMilliseconds,
+                CircuitBreakerForcedOpen = defaultConfig.CircuitBreakerForcedOpen,
+                CircuitBreakerForcedClosed = defaultConfig.CircuitBreakerForcedClosed,
+                CircuitBreakerErrorThresholdPercentage = defaultConfig.CircuitBreakerErrorThresholdPercentage,
+                CircuitBreakerSleepWindowInMilliseconds = defaultConfig.CircuitBreakerSleepWindowInMilliseconds,
+                CircuitBreakerRequestVolumeThreshold = defaultConfig.CircuitBreakerRequestVolumeThreshold,
+                MetricsHealthSnapshotIntervalInMilliseconds = defaultConfig.MetricsHealthSnapshotIntervalInMilliseconds,
+                MetricsRollingStatisticalWindowInMilliseconds = defaultConfig.MetricsRollingStatisticalWindowInMilliseconds,
+                MetricsRollingStatisticalWindowBuckets = defaultConfig.MetricsRollingStatisticalWindowBuckets,
+                MetricsRollingPercentileEnabled = defaultConfig.MetricsRollingPercentileEnabled,
+                MetricsRollingPercentileWindowInMilliseconds = defaultConfig.MetricsRollingPercentileWindowInMilliseconds,
+                MetricsRollingPercentileWindowBuckets = defaultConfig.MetricsRollingPercentileWindowBuckets,
+                MetricsRollingPercentileBucketSize = defaultConfig.MetricsRollingPercentileBucketSize,
+                HystrixCommandEnabled = defaultConfig.HystrixCommandEnabled,
             };
         }
 

--- a/src/Hystrix.Dotnet.AspNet/HystrixDefaultConfigurationElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixDefaultConfigurationElement.cs
@@ -4,7 +4,7 @@ namespace Hystrix.Dotnet.AspNet
 {
     public class HystrixDefaultConfigurationElement : ConfigurationElement
     {
-        [ConfigurationProperty("commandTimeoutInMilliseconds", IsRequired = false, DefaultValue = 1000)]
+        [ConfigurationProperty("commandTimeoutInMilliseconds", IsRequired = false, DefaultValue = 60000)]
         public int CommandTimeoutInMilliseconds
         {
             get => (int)this["commandTimeoutInMilliseconds"];

--- a/src/Hystrix.Dotnet.AspNet/HystrixDefaultConfigurationElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixDefaultConfigurationElement.cs
@@ -1,0 +1,105 @@
+﻿using System.Configuration;
+
+namespace Hystrix.Dotnet.AspNet
+{
+    public class HystrixDefaultConfigurationElement : ConfigurationElement
+    {
+        [ConfigurationProperty("commandTimeoutInMilliseconds", IsRequired = false, DefaultValue = 1000)]
+        public int CommandTimeoutInMilliseconds
+        {
+            get => (int)this["commandTimeoutInMilliseconds"];
+            set => this["commandTimeoutInMilliseconds"] = value;
+        }
+
+        [ConfigurationProperty("circuitBreakerForcedOpen", IsRequired = false, DefaultValue = false)]
+        public bool CircuitBreakerForcedOpen
+        {
+            get => (bool)this["circuitBreakerForcedOpen"];
+            set => this["circuitBreakerForcedOpen"] = value;
+        }
+
+        [ConfigurationProperty("circuitBreakerForcedClosed", IsRequired = false, DefaultValue = false)]
+        public bool CircuitBreakerForcedClosed
+        {
+            get => (bool)this["circuitBreakerForcedClosed"];
+            set => this["circuitBreakerForcedClosed"] = value;
+        }
+
+        [ConfigurationProperty("circuitBreakerErrorThresholdPercentage", IsRequired = false, DefaultValue = 50)]
+        public int CircuitBreakerErrorThresholdPercentage
+        {
+            get => (int)this["circuitBreakerErrorThresholdPercentage"];
+            set => this["circuitBreakerErrorThresholdPercentage"] = value;
+        }
+
+        [ConfigurationProperty("circuitBreakerSleepWindowInMilliseconds", IsRequired = false, DefaultValue = 5000)]
+        public int CircuitBreakerSleepWindowInMilliseconds
+        {
+            get => (int)this["circuitBreakerSleepWindowInMilliseconds"];
+            set => this["circuitBreakerSleepWindowInMilliseconds"] = value;
+        }
+
+        [ConfigurationProperty("circuitBreakerRequestVolumeThreshold", IsRequired = false, DefaultValue = 20)]
+        public int CircuitBreakerRequestVolumeThreshold
+        {
+            get => (int)this["circuitBreakerRequestVolumeThreshold"];
+            set => this["circuitBreakerRequestVolumeThreshold"] = value;
+        }
+
+        [ConfigurationProperty("metricsHealthSnapshotIntervalInMilliseconds", IsRequired = false, DefaultValue = 500)]
+        public int MetricsHealthSnapshotIntervalInMilliseconds
+        {
+            get => (int)this["metricsHealthSnapshotIntervalInMilliseconds"];
+            set => this["metricsHealthSnapshotIntervalInMilliseconds"] = value;
+        }
+
+        [ConfigurationProperty("metricsRollingStatisticalWindowInMilliseconds", IsRequired = false, DefaultValue = 10000)]
+        public int MetricsRollingStatisticalWindowInMilliseconds
+        {
+            get => (int)this["metricsRollingStatisticalWindowInMilliseconds"];
+            set => this["metricsRollingStatisticalWindowInMilliseconds"] = value;
+        }
+
+        [ConfigurationProperty("metricsRollingStatisticalWindowBuckets", IsRequired = false, DefaultValue = 10)]
+        public int MetricsRollingStatisticalWindowBuckets
+        {
+            get => (int)this["metricsRollingStatisticalWindowBuckets"];
+            set => this["metricsRollingStatisticalWindowBuckets"] = value;
+        }
+
+        [ConfigurationProperty("metricsRollingPercentileEnabled", IsRequired = false, DefaultValue = true)]
+        public bool MetricsRollingPercentileEnabled
+        {
+            get => (bool)this["metricsRollingPercentileEnabled"];
+            set => this["metricsRollingPercentileEnabled"] = value;
+        }
+
+        [ConfigurationProperty("metricsRollingPercentileWindowInMilliseconds", IsRequired = false, DefaultValue = 60000)]
+        public int MetricsRollingPercentileWindowInMilliseconds
+        {
+            get => (int)this["metricsRollingPercentileWindowInMilliseconds"];
+            set => this["metricsRollingPercentileWindowInMilliseconds"] = value;
+        }
+
+        [ConfigurationProperty("metricsRollingPercentileWindowBuckets", IsRequired = false, DefaultValue = 6)]
+        public int MetricsRollingPercentileWindowBuckets
+        {
+            get => (int)this["metricsRollingPercentileWindowBuckets"];
+            set => this["metricsRollingPercentileWindowBuckets"] = value;
+        }
+
+        [ConfigurationProperty("metricsRollingPercentileBucketSize", IsRequired = false, DefaultValue = 100)]
+        public int MetricsRollingPercentileBucketSize
+        {
+            get => (int)this["metricsRollingPercentileBucketSize"];
+            set => this["metricsRollingPercentileBucketSize"] = value;
+        }
+
+        [ConfigurationProperty("hystrixCommandEnabled", IsRequired = false, DefaultValue = true)]
+        public bool HystrixCommandEnabled
+        {
+            get => (bool)this["hystrixCommandEnabled"];
+            set => this["hystrixCommandEnabled"] = value;
+        }
+    }
+}

--- a/src/Hystrix.Dotnet.AspNet/HystrixLocalOptionsElement.cs
+++ b/src/Hystrix.Dotnet.AspNet/HystrixLocalOptionsElement.cs
@@ -11,5 +11,12 @@ namespace Hystrix.Dotnet.AspNet
             get => (HystrixCommandGroupCollection)this["commandGroups"];
             set => this["commandGroups"] = value;
         }
+
+        [ConfigurationProperty("defaultConfiguration", DefaultValue = null)]
+        public HystrixDefaultConfigurationElement DefaultConfiguration
+        {
+            get => (HystrixDefaultConfigurationElement)this["defaultConfiguration"];
+            set => this["defaultConfiguration"] = value;
+        }
     }
 }

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>ASP.NET extensions for Hystrix.Dotnet, the .NET version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <NoWarn>$(NoWarn);0618</NoWarn>

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A combination of circuit breaker and timeout. The .net version of the open source Hystrix library built by Netflix.</Description>
     <Authors>Travix International</Authors>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Hystrix.Dotnet/HystrixJsonConfigConfigurationService.cs
+++ b/src/Hystrix.Dotnet/HystrixJsonConfigConfigurationService.cs
@@ -174,7 +174,7 @@ namespace Hystrix.Dotnet
         /// <inheritdoc/>
         public int GetCommandTimeoutInMilliseconds()
         {
-            return configurationObject != null ? configurationObject.CommandTimeoutInMilliseconds : 1000;
+            return configurationObject != null ? configurationObject.CommandTimeoutInMilliseconds : 60000;
         }
 
         /// <inheritdoc/>

--- a/src/Hystrix.Dotnet/HystrixLocalOptions.cs
+++ b/src/Hystrix.Dotnet/HystrixLocalOptions.cs
@@ -16,27 +16,25 @@ namespace Hystrix.Dotnet
 
         public Dictionary<string, Dictionary<string, HystrixCommandOptions>> CommandGroups { get; set; }
 
+        public HystrixCommandOptions DefaultOptions { get; set; }
+
         public HystrixCommandOptions GetCommandOptions(HystrixCommandIdentifier id) => GetCommandOptions(id.GroupKey, id.CommandKey);
 
         public HystrixCommandOptions GetCommandOptions(string groupKey, string commandKey)
         {
             if (CommandGroups == null)
             {
-                return HystrixCommandOptions.CreateDefault();
+                return DefaultOptions ?? HystrixCommandOptions.CreateDefault();
             }
 
-            Dictionary<string, HystrixCommandOptions> groupCommands;
-
-            if (!CommandGroups.TryGetValue(groupKey, out groupCommands))
+            if (!CommandGroups.TryGetValue(groupKey, out var groupCommands))
             {
-                return HystrixCommandOptions.CreateDefault();
+                return DefaultOptions ?? HystrixCommandOptions.CreateDefault();
             }
 
-            HystrixCommandOptions commandOptions;
-
-            if (!groupCommands.TryGetValue(commandKey, out commandOptions))
+            if (!groupCommands.TryGetValue(commandKey, out var commandOptions))
             {
-                return HystrixCommandOptions.CreateDefault();
+                return DefaultOptions ?? HystrixCommandOptions.CreateDefault();
             }
 
             return commandOptions;

--- a/src/Hystrix.Dotnet/HystrixOptionsDetails.cs
+++ b/src/Hystrix.Dotnet/HystrixOptionsDetails.cs
@@ -7,7 +7,7 @@
             return new HystrixCommandOptions();
         }
 
-        public int CommandTimeoutInMilliseconds { get; set; } = 1000;
+        public int CommandTimeoutInMilliseconds { get; set; } = 60000;
 
         public bool CircuitBreakerForcedOpen { get; set; } = false;
 

--- a/test/Hystrix.Dotnet.AspNet.UnitTests/HystrixConfigSectionTranslatorTests.cs
+++ b/test/Hystrix.Dotnet.AspNet.UnitTests/HystrixConfigSectionTranslatorTests.cs
@@ -52,6 +52,23 @@ namespace Hystrix.Dotnet.AspNet.UnitTests
                 },
                 LocalOptions = new HystrixLocalOptionsElement
                 {
+                    DefaultConfiguration = new HystrixDefaultConfigurationElement
+                    {
+                        CommandTimeoutInMilliseconds = 1001,
+                        CircuitBreakerForcedOpen = true,
+                        CircuitBreakerForcedClosed = false,
+                        CircuitBreakerErrorThresholdPercentage = 1002,
+                        CircuitBreakerSleepWindowInMilliseconds = 1003,
+                        CircuitBreakerRequestVolumeThreshold = 1004,
+                        MetricsHealthSnapshotIntervalInMilliseconds = 1005,
+                        MetricsRollingStatisticalWindowInMilliseconds = 1006,
+                        MetricsRollingStatisticalWindowBuckets = 1007,
+                        MetricsRollingPercentileEnabled = true,
+                        MetricsRollingPercentileWindowInMilliseconds = 1008,
+                        MetricsRollingPercentileWindowBuckets = 1009,
+                        MetricsRollingPercentileBucketSize = 1010,
+                        HystrixCommandEnabled = false
+                    },
                     CommandGroups = new TestHystrixCommandGroupCollection
                     {
                         new HystrixCommandGroupElement
@@ -62,19 +79,19 @@ namespace Hystrix.Dotnet.AspNet.UnitTests
                                 new HystrixCommandElement
                                 {
                                     Key = "CommandA",
-                                    CommandTimeoutInMilliseconds = 1001,
+                                    CommandTimeoutInMilliseconds = 2001,
                                     CircuitBreakerForcedOpen = true,
                                     CircuitBreakerForcedClosed = false,
-                                    CircuitBreakerErrorThresholdPercentage = 1002,
-                                    CircuitBreakerSleepWindowInMilliseconds = 1003,
-                                    CircuitBreakerRequestVolumeThreshold = 1004,
-                                    MetricsHealthSnapshotIntervalInMilliseconds = 1005,
-                                    MetricsRollingStatisticalWindowInMilliseconds = 1006,
-                                    MetricsRollingStatisticalWindowBuckets = 1007,
+                                    CircuitBreakerErrorThresholdPercentage = 2002,
+                                    CircuitBreakerSleepWindowInMilliseconds = 2003,
+                                    CircuitBreakerRequestVolumeThreshold = 2004,
+                                    MetricsHealthSnapshotIntervalInMilliseconds = 2005,
+                                    MetricsRollingStatisticalWindowInMilliseconds = 2006,
+                                    MetricsRollingStatisticalWindowBuckets = 2007,
                                     MetricsRollingPercentileEnabled = true,
-                                    MetricsRollingPercentileWindowInMilliseconds = 1008,
-                                    MetricsRollingPercentileWindowBuckets = 1009,
-                                    MetricsRollingPercentileBucketSize = 1010,
+                                    MetricsRollingPercentileWindowInMilliseconds = 2008,
+                                    MetricsRollingPercentileWindowBuckets = 2009,
+                                    MetricsRollingPercentileBucketSize = 2010,
                                     HystrixCommandEnabled = false
                                 },
                                 new HystrixCommandElement
@@ -109,20 +126,36 @@ namespace Hystrix.Dotnet.AspNet.UnitTests
 
             Assert.True(options.LocalOptions.CommandGroups["GroupA"].ContainsKey("CommandA"));
 
+            var defaultConfig = options.LocalOptions.DefaultOptions;
+            Assert.Equal(1001, defaultConfig.CommandTimeoutInMilliseconds);
+            Assert.Equal(true, defaultConfig.CircuitBreakerForcedOpen);
+            Assert.Equal(false, defaultConfig.CircuitBreakerForcedClosed);
+            Assert.Equal(1002, defaultConfig.CircuitBreakerErrorThresholdPercentage);
+            Assert.Equal(1003, defaultConfig.CircuitBreakerSleepWindowInMilliseconds);
+            Assert.Equal(1004, defaultConfig.CircuitBreakerRequestVolumeThreshold);
+            Assert.Equal(1005, defaultConfig.MetricsHealthSnapshotIntervalInMilliseconds);
+            Assert.Equal(1006, defaultConfig.MetricsRollingStatisticalWindowInMilliseconds);
+            Assert.Equal(1007, defaultConfig.MetricsRollingStatisticalWindowBuckets);
+            Assert.Equal(true, defaultConfig.MetricsRollingPercentileEnabled);
+            Assert.Equal(1008, defaultConfig.MetricsRollingPercentileWindowInMilliseconds);
+            Assert.Equal(1009, defaultConfig.MetricsRollingPercentileWindowBuckets);
+            Assert.Equal(1010, defaultConfig.MetricsRollingPercentileBucketSize);
+            Assert.Equal(false, defaultConfig.HystrixCommandEnabled);
+
             var commandA = options.LocalOptions.CommandGroups["GroupA"]["CommandA"];
-            Assert.Equal(1001, commandA.CommandTimeoutInMilliseconds);
+            Assert.Equal(2001, commandA.CommandTimeoutInMilliseconds);
             Assert.Equal(true, commandA.CircuitBreakerForcedOpen);
             Assert.Equal(false, commandA.CircuitBreakerForcedClosed);
-            Assert.Equal(1002, commandA.CircuitBreakerErrorThresholdPercentage);
-            Assert.Equal(1003, commandA.CircuitBreakerSleepWindowInMilliseconds);
-            Assert.Equal(1004, commandA.CircuitBreakerRequestVolumeThreshold);
-            Assert.Equal(1005, commandA.MetricsHealthSnapshotIntervalInMilliseconds);
-            Assert.Equal(1006, commandA.MetricsRollingStatisticalWindowInMilliseconds);
-            Assert.Equal(1007, commandA.MetricsRollingStatisticalWindowBuckets);
+            Assert.Equal(2002, commandA.CircuitBreakerErrorThresholdPercentage);
+            Assert.Equal(2003, commandA.CircuitBreakerSleepWindowInMilliseconds);
+            Assert.Equal(2004, commandA.CircuitBreakerRequestVolumeThreshold);
+            Assert.Equal(2005, commandA.MetricsHealthSnapshotIntervalInMilliseconds);
+            Assert.Equal(2006, commandA.MetricsRollingStatisticalWindowInMilliseconds);
+            Assert.Equal(2007, commandA.MetricsRollingStatisticalWindowBuckets);
             Assert.Equal(true, commandA.MetricsRollingPercentileEnabled);
-            Assert.Equal(1008, commandA.MetricsRollingPercentileWindowInMilliseconds);
-            Assert.Equal(1009, commandA.MetricsRollingPercentileWindowBuckets);
-            Assert.Equal(1010, commandA.MetricsRollingPercentileBucketSize);
+            Assert.Equal(2008, commandA.MetricsRollingPercentileWindowInMilliseconds);
+            Assert.Equal(2009, commandA.MetricsRollingPercentileWindowBuckets);
+            Assert.Equal(2010, commandA.MetricsRollingPercentileBucketSize);
             Assert.Equal(false, commandA.HystrixCommandEnabled);
 
             Assert.True(options.LocalOptions.CommandGroups["GroupA"].ContainsKey("CommandB"));

--- a/test/Hystrix.Dotnet.UnitTests/HystrixWebConfigConfigurationServiceTests.cs
+++ b/test/Hystrix.Dotnet.UnitTests/HystrixWebConfigConfigurationServiceTests.cs
@@ -52,7 +52,7 @@ namespace Hystrix.Dotnet.UnitTests
             }
 
             [Fact]
-            public void Returns_1000_If_AppSetting_Does_Not_Exist()
+            public void Returns_60000_If_AppSetting_Does_Not_Exist()
             {
                 var hystrixCommandIdentifier = new HystrixCommandIdentifier("NonExistingGroup", "NonExistingCommand");
                 var hystrixConfigurationService = new HystrixLocalConfigurationService(hystrixCommandIdentifier, options);
@@ -60,7 +60,7 @@ namespace Hystrix.Dotnet.UnitTests
                 // Act
                 int value = hystrixConfigurationService.GetCommandTimeoutInMilliseconds();
 
-                Assert.Equal(1000, value);
+                Assert.Equal(60000, value);
             }
         }
 


### PR DESCRIPTION
This PR introduces the capability to configure a "default" configuration when using local options, so that when we use commands for which we don't have a specific config, we fall back to the default one.