### PR TITLE
Fix CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ skip_tags: true
 #    environment configuration    #
 #---------------------------------#
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 clone_depth: 1
 

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+    <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -11,10 +11,14 @@
     <AssemblyName>Hystrix.Dotnet.AspNet</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hystrix.Dotnet\Hystrix.Dotnet.csproj" />

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -11,14 +11,10 @@
     <AssemblyName>Hystrix.Dotnet.AspNet</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hystrix.Dotnet\Hystrix.Dotnet.csproj" />

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Hystrix.Dotnet.AspNet</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Hystrix.Dotnet.AspNet</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
+++ b/src/Hystrix.Dotnet.AspNet/Hystrix.Dotnet.AspNet.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Hystrix.Dotnet.AspNet</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Hystrix.Dotnet.AspNetCore</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNetCore</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+    <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -11,10 +11,14 @@
     <AssemblyName>Hystrix.Dotnet.AspNetCore</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNetCore</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hystrix.Dotnet\Hystrix.Dotnet.csproj" />

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Hystrix.Dotnet.AspNetCore</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNetCore</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Hystrix.Dotnet.AspNetCore</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNetCore</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>

--- a/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
+++ b/src/Hystrix.Dotnet.AspNetCore/Hystrix.Dotnet.AspNetCore.csproj
@@ -11,14 +11,10 @@
     <AssemblyName>Hystrix.Dotnet.AspNetCore</AssemblyName>
     <PackageId>Hystrix.Dotnet.AspNetCore</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Hystrix.Dotnet\Hystrix.Dotnet.csproj" />

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+    <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Hystrix.Dotnet</AssemblyName>
     <PackageId>Hystrix.Dotnet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
     <DefineConstants>LIBLOG_PORTABLE;LIBLOG_PUBLIC</DefineConstants>

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Hystrix.Dotnet</AssemblyName>
     <PackageId>Hystrix.Dotnet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>https://raw.githubusercontent.com/Travix-International/Hystrix.Dotnet/master/LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
     <DefineConstants>LIBLOG_PORTABLE;LIBLOG_PUBLIC</DefineConstants>

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -12,11 +12,15 @@
     <AssemblyName>Hystrix.Dotnet</AssemblyName>
     <PackageId>Hystrix.Dotnet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
     <DefineConstants>LIBLOG_PORTABLE;LIBLOG_PUBLIC</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../LICENSE.txt" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="App.config" />

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Hystrix.Dotnet</AssemblyName>
     <PackageId>Hystrix.Dotnet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
     <DefineConstants>LIBLOG_PORTABLE;LIBLOG_PUBLIC</DefineConstants>

--- a/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
+++ b/src/Hystrix.Dotnet/Hystrix.Dotnet.csproj
@@ -12,15 +12,11 @@
     <AssemblyName>Hystrix.Dotnet</AssemblyName>
     <PackageId>Hystrix.Dotnet</PackageId>
     <PackageProjectUrl>https://github.com/Travix-International/Hystrix.Dotnet</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/Travix-International/Hystrix.Dotnet.git</RepositoryUrl>
     <DefineConstants>LIBLOG_PORTABLE;LIBLOG_PUBLIC</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
The `PackageLicenseUrl` field is deprecated, it was causing a failing build.